### PR TITLE
Revert "genpoi: ignore dat files with incomplete player info"

### DIFF
--- a/overviewer_core/aux_files/genPOI.py
+++ b/overviewer_core/aux_files/genPOI.py
@@ -331,9 +331,6 @@ def handlePlayers(worldpath, filters, markers):
         except (IOError, TypeError, KeyError, nbt.CorruptNBTError):
             logging.warning("Skipping bad player dat file %r.", playerfile)
             continue
-        if not "_name" in data:
-            logging.warning("Skipping bad player dat file %r (incomplete player info).", playerfile)
-            continue
 
         playername = playerfile.split(".")[0]
         if isSinglePlayer:


### PR DESCRIPTION
This reverts commit 44ffb2658e504313e555ff03d97c155d2f1e084b.

Breaks player handling in genpoi.